### PR TITLE
Release 0.1.1. Minor fix.

### DIFF
--- a/src/OwlCore.Nomad.csproj
+++ b/src/OwlCore.Nomad.csproj
@@ -14,13 +14,17 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.1.0</Version>
+		<Version>0.1.1</Version>
 		<Product>OwlCore</Product>
 		<Description></Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.1.1 ---
+[Fixes]
+Added missing `this` keyword to first parameter of EventStreamExtensions.AdvanceFullEventStreamAsync.
+
 --- 0.1.0 ---
 [New]
 Added EventStreamExtensions.AdvanceFullEventStreamAsync. This helper resolves and advances all listeners on a shared event stream handler.


### PR DESCRIPTION
Added missing `this` keyword to first parameter of EventStreamExtensions.AdvanceFullEventStreamAsync