### PR TITLE
Release 0.10.0

### DIFF
--- a/src/IEventStreamHandler.cs
+++ b/src/IEventStreamHandler.cs
@@ -9,10 +9,11 @@ namespace OwlCore.Nomad;
 /// </summary>
 /// <typeparam name="TEventStream">The type used for the local event stream.</typeparam>
 /// <typeparam name="TEventStreamEntry">The type for the resolved event stream entries.</typeparam>
-/// <typeparam name="TContentPointer">An immutable pointer to data in the event stream.</typeparam>
-public interface IEventStreamHandler<TContentPointer, TEventStream, TEventStreamEntry> : ISources<TContentPointer>
-    where TEventStream : EventStream<TContentPointer>
-    where TEventStreamEntry : EventStreamEntry<TContentPointer>
+/// <typeparam name="TImmutablePointer">An immutable pointer to data in the event stream.</typeparam>
+/// <typeparam name="TMutablePointer">A pointer to mutable data in the event stream.</typeparam>
+public interface IEventStreamHandler<TImmutablePointer, TMutablePointer, TEventStream, TEventStreamEntry> : ISources<TMutablePointer>
+    where TEventStream : EventStream<TImmutablePointer>
+    where TEventStreamEntry : EventStreamEntry<TImmutablePointer>
 {
     /// <summary>
     /// A unique identifier for this event stream handler.

--- a/src/OwlCore.Nomad.csproj
+++ b/src/OwlCore.Nomad.csproj
@@ -14,13 +14,17 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.9.0</Version>
+		<Version>0.10.0</Version>
 		<Product>OwlCore</Product>
 		<Description>A lightweight distributed event sourcing framework.</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.10.0 ---
+[Breaking]
+Refactor IEventStreamHandler interface to use separate generic types for immutable and mutable pointers.
+
 --- 0.9.0 ---
 [Breaking]
 Removed ISharedEventStreamHandler and the ListeningEventStreamHandlers property on it. This pattern is not recommended for wiring update events, manage at the point of object instantiation instead.


### PR DESCRIPTION
This release sees one major breaking change. 
- Refactored `IEventStreamHandler` interface to use separate generic types for immutable and mutable pointers.

This creates a distinction between pointer types: pointers that never change, and pointers that may change. This is a practically useful distinction for consuming libraries, especially as the mutability of `Sources` and the immutability of event stream entries is known and expected as part of the implementation.  